### PR TITLE
Fix bug in --docdb-password-file option handling.

### DIFF
--- a/wscript
+++ b/wscript
@@ -138,7 +138,7 @@ class manifest(Task):
 def spreadsheet_updater(bld):
     secret = bld.options.docdb_password
     if not secret and bld.options.docdb_password_file:
-        secret = bld.path.find_resource().read(bld.options.docdb_password_file).strip()
+        secret = bld.path.find_resource(bld.options.docdb_password_file).read().strip()
     if not secret:
         print ('Note: no --docdb-password[-file] given, spreadsheets will not be updated.')
         return None


### PR DESCRIPTION
Just a minor bug fix to make the --docdb-password-file option work.  (The filename wasn't being passed to the find_resource() function.)